### PR TITLE
Upgrade symfony serializer to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/serializer": "^6.0",
+        "symfony/serializer": "^7.0",
         "paragonie/random_compat": "*"
     },
     "require-dev": {

--- a/src/Search.php
+++ b/src/Search.php
@@ -155,10 +155,11 @@ class Search
     private function initializeSerializer(): void
     {
         if (!static::$serializer instanceof OrderedSerializer) {
+            $customNormalizer = new CustomNormalizer();
             static::$serializer = new OrderedSerializer(
                 [
-                    new CustomReferencedNormalizer(),
-                    new CustomNormalizer(),
+                    new CustomReferencedNormalizer($customNormalizer),
+                    $customNormalizer,
                 ]
             );
         }


### PR DESCRIPTION
The CustomSerializer class was made final, so the CustomReferencedNormalizer class must be updated to use composition over inheritance

https://github.com/symfony/symfony/blob/7.3/UPGRADE-7.0.md#serializer