### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/serializer": "^7.0",
-        "paragonie/random_compat": "*"
+        "symfony/serializer": "^7.0"
     },
     "require-dev": {
         "elasticsearch/elasticsearch": "^8.0",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: *`, but also `php: >=8.1`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?